### PR TITLE
Support publishing to local maven repository. Version bump 0.1.3-SNAPSHOT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,16 @@ build: clean
 docs: clean
 	sbt "project connectorLib" doc
 
+.PHONY: m2publish
+m2publish: clean
+	sbt "project connectorLib" publish
+
+
 .PHONY: package
 package: docs build
 	mkdir -p distribution/dist/memsqlrdd-$(MEMSQLRDD_VERSION)
 	cp README.md distribution/dist/memsqlrdd-$(MEMSQLRDD_VERSION)/
-	cp connectorLib/target/scala-2.10/MemSQLRDD-assembly-$(MEMSQLRDD_VERSION).jar distribution/dist/memsqlrdd-$(MEMSQLRDD_VERSION)/
+	cp connectorLib/target/scala-2.10/memsql-spark-connector-assembly-$(MEMSQLRDD_VERSION).jar distribution/dist/memsqlrdd-$(MEMSQLRDD_VERSION)/
 	cp -r connectorLib/target/scala-2.10/api/ distribution/dist/memsqlrdd-$(MEMSQLRDD_VERSION)/docs/
 	cd distribution/dist; \
 	tar cvzf memsqlrdd-$(MEMSQLRDD_VERSION).tar.gz memsqlrdd-$(MEMSQLRDD_VERSION)/

--- a/README.md
+++ b/README.md
@@ -59,6 +59,28 @@ This directory will also contain HTML documentation for the connector.
 In order to compile this connector, you must have the [Simple Build
 Tool (aka sbt)](http://www.scala-sbt.org/) installed.
 
+Publishing
+----------
+Run ``make m2publish`` to publish the connector to your local Maven
+repository. To use it, include the following in your pom.xml:
+
+```
+    <dependency>
+      <groupId>com.memsql</groupId>
+      <artifactId>memsql-spark-connector_2.10</artifactId>
+      <version>0.1.3-SNAPSHOT</version>
+    </dependency>
+```
+
+Or, if you are using sbt:
+
+```
+libraryDependencies += "com.memsql" % "memsql-spark-connector_2.10" % "0.1.3-SNAPSHOT"
+```
+
+Note: you should change 0.1.3-SNAPSHOT if the version has been updated.
+You can run ``make version`` to get the current version.
+
 Tweaks
 ------
 The saveToMemsql function has an optional insertBatchSize argument. This

--- a/memsqlrdd_app.sbt
+++ b/memsqlrdd_app.sbt
@@ -1,13 +1,19 @@
+lazy val commonSettings = Seq(
+  organization := "com.memsql",
+  version := "0.1.3-SNAPSHOT",
+  scalaVersion := "2.10.4"
+)
+
 lazy val connectorLib = (project in file("connectorLib")).
+  settings(commonSettings: _*).
   settings(
-    name := "MemSQLRDD",
-    version := "0.1.2",
-    scalaVersion := "2.10.4",
+    name := "memsql-spark-connector",
     libraryDependencies  ++= Seq(
-      "org.apache.spark" %% "spark-core" % "1.1.0" % "provided",
+      "org.apache.spark" %% "spark-core" % "1.4.1" % "provided",
       "mysql" % "mysql-connector-java" % "5.1.34"
     ),
     autoAPIMappings := true,
+    publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository"))),
     apiMappings ++= {
       def findManagedDependency(organization: String, name: String): Option[File] = {
         (for {
@@ -24,12 +30,11 @@ lazy val connectorLib = (project in file("connectorLib")).
 
 lazy val root = (project in file(".")).
   dependsOn(connectorLib).
+  settings(commonSettings: _*).
   settings(
     name := "MemSQLRDDApp",
-    version := "0.1.2",
-    scalaVersion := "2.10.4",
     libraryDependencies  ++= Seq(
-      "org.apache.spark" %% "spark-core" % "1.1.0" % "provided",
+      "org.apache.spark" %% "spark-core" % "1.4.1" % "provided",
       "mysql" % "mysql-connector-java" % "5.1.34"
     )
   )


### PR DESCRIPTION
* Bump to latest version of spark dependencies
* Version bump from 0.1.2 to 0.1.3-SNAPSHOT
* Rename the artifact id for the connector to match the name of the repository
* Specify the correct org name of com.memsql
* Support publishing to a local maven repository via `make m2publish`
