### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MemSQL Spark Connector
 ## Version: 3.0.0-beta2 [![Build Status](https://travis-ci.com/memsql/memsql-spark-connector.svg?branch=3.0.0-beta)](https://travis-ci.com/memsql/memsql-spark-connector) [![License](http://img.shields.io/:license-Apache%202-brightgreen.svg)](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-> :warning: **This is a beta release**: [Go back to the stable branch](https://github.com/memsql/memsql-spark-connector)
+> :warning: **This is a beta release suitable for development and testing purposes.** 
 
 ## Major changes from the 2.0.0 connector
 


### PR DESCRIPTION
Removing link to "stable branch" in the beta of the Spark Connector so more newcomers use 3.0. Adding more details to the beta description noting that it's suitable for development and testing purposes.