### PR TITLE
Forwardport: fix of the bug in codegen of join conditions

### DIFF
--- a/src/main/scala/com/memsql/spark/MemsqlOptions.scala
+++ b/src/main/scala/com/memsql/spark/MemsqlOptions.scala
@@ -167,7 +167,8 @@ object MemsqlOptions extends LazyLogging {
 
     new MemsqlOptions(
       ddlEndpoint = options(DDL_ENDPOINT),
-      dmlEndpoints = options.getOrElse(DML_ENDPOINTS, options(DDL_ENDPOINT)).split(",").toList,
+      dmlEndpoints =
+        options.getOrElse(DML_ENDPOINTS, options(DDL_ENDPOINT)).split(",").toList.sorted,
       user = options.getOrElse(USER, "root"),
       password = options.getOrElse(PASSWORD, ""),
       database = options.get(DATABASE).orElse(table.flatMap(t => t.database)),

--- a/src/test/scala/com/memsql/spark/IntegrationSuiteBase.scala
+++ b/src/test/scala/com/memsql/spark/IntegrationSuiteBase.scala
@@ -91,6 +91,7 @@ trait IntegrationSuiteBase
       .config("spark.datasource.memsql.serverSslCert",
               s"${System.getProperty("user.dir")}/scripts/ssl/test-ca-cert.pem")
       .config("spark.datasource.memsql.disableSslHostnameVerification", "true")
+      .config("spark.sql.crossJoin.enabled", "true")
       .getOrCreate()
   }
 

--- a/src/test/scala/com/memsql/spark/MemsqlOptionsTest.scala
+++ b/src/test/scala/com/memsql/spark/MemsqlOptionsTest.scala
@@ -1,0 +1,21 @@
+package com.memsql.spark
+
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
+
+class MemsqlOptionsTest extends IntegrationSuiteBase {
+  val requiredOptions = Map("ddlEndpoint" -> "h:3306")
+
+  describe("equality") {
+    it("should sort dmlEndpoints") {
+      assert(
+        MemsqlOptions(
+          CaseInsensitiveMap(
+            requiredOptions ++ Map("dmlEndpoints" -> "host1:3302,host2:3302,host1:3342"))) ==
+          MemsqlOptions(
+            CaseInsensitiveMap(
+              requiredOptions ++ Map("dmlEndpoints" -> "host2:3302,host1:3302,host1:3342"))),
+        "Should sort dmlEndpoints"
+      )
+    }
+  }
+}

--- a/src/test/scala/com/memsql/spark/SQLPushdownTest.scala
+++ b/src/test/scala/com/memsql/spark/SQLPushdownTest.scala
@@ -4,6 +4,7 @@ import com.memsql.spark.SQLGen.{MemsqlVersion, Relation}
 import org.apache.log4j.{Level, LogManager}
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.types._
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
@@ -79,6 +80,8 @@ class SQLPushdownTest extends IntegrationSuiteBase with BeforeAndAfterEach with 
     makeTables("users_sample")
     makeTables("movies")
     makeTables("reviews")
+
+    spark.udf.register("stringIdentity", (s: String) => s)
   }
 
   def extractQueriesFromPlan(root: LogicalPlan): Seq[String] = {
@@ -441,38 +444,199 @@ class SQLPushdownTest extends IntegrationSuiteBase with BeforeAndAfterEach with 
   }
 
   describe("joins") {
-    it("implicit inner join") {
-      testSingleReadQuery("select * from users as a, reviews where a.id = reviews.user_id")
+    describe("successful pushdown") {
+      it("implicit inner join") {
+        testSingleReadQuery("select * from users as a, reviews where a.id = reviews.user_id")
+      }
+      it("explicit inner join") {
+        testSingleReadQuery("select * from users inner join reviews on users.id = reviews.user_id")
+      }
+      it("cross join") {
+        testSingleReadQuery("select * from users cross join reviews on users.id = reviews.user_id")
+      }
+      it("left outer join") {
+        testSingleReadQuery(
+          "select * from users left outer join reviews on users.id = reviews.user_id")
+      }
+      it("right outer join") {
+        testSingleReadQuery(
+          "select * from users right outer join reviews on users.id = reviews.user_id")
+      }
+      it("full outer join") {
+        testSingleReadQuery(
+          "select * from users full outer join reviews on users.id = reviews.user_id")
+      }
+      it("natural join") {
+        testSingleReadQuery(
+          "select users.id, rating from users natural join (select user_id as id, rating from reviews)")
+      }
+      it("complex join") {
+        testSingleReadQuery(
+          """
+            |  select users.id, round(avg(rating), 2) as rating, count(*) as num_reviews
+            |  from users inner join reviews on users.id = reviews.user_id
+            | group by users.id
+            |""".stripMargin)
+      }
+      it("inner join without condition") {
+        testSingleReadQuery(
+          "select * from users inner join reviews order by concat(users.id, ' ', reviews.user_id, ' ', reviews.movie_id) limit 10")
+      }
+      it("cross join without condition") {
+        testSingleReadQuery(
+          "select * from users cross join reviews order by concat(users.id, ' ', reviews.user_id, ' ', reviews.movie_id) limit 10")
+      }
     }
-    it("explicit inner join") {
-      testSingleReadQuery("select * from users inner join reviews on users.id = reviews.user_id")
-    }
-    it("cross join") {
-      testSingleReadQuery("select * from users cross join reviews on users.id = reviews.user_id")
-    }
-    it("left outer join") {
-      testSingleReadQuery(
-        "select * from users left outer join reviews on users.id = reviews.user_id")
-    }
-    it("right outer join") {
-      testSingleReadQuery(
-        "select * from users right outer join reviews on users.id = reviews.user_id")
-    }
-    it("full outer join") {
-      testSingleReadQuery(
-        "select * from users full outer join reviews on users.id = reviews.user_id")
-    }
-    it("natural join") {
-      testSingleReadQuery(
-        "select users.id, rating from users natural join (select user_id as id, rating from reviews)")
-    }
-    it("complex join") {
-      testSingleReadQuery(
-        """
-          |  select users.id, round(avg(rating), 2) as rating, count(*) as num_reviews
-          |  from users inner join reviews on users.id = reviews.user_id
-          | group by users.id
-          |""".stripMargin)
+
+    describe("unsuccessful pushdown") {
+      describe("udf in the left relation") {
+        it("explicit inner join") {
+          testSingleReadQuery(
+            "select * from (select rating, stringIdentity(user_id) as user_id from reviews) inner join users on users.id = user_id",
+            expectPartialPushdown = true)
+        }
+        it("cross join") {
+          testSingleReadQuery(
+            "select * from (select rating, stringIdentity(user_id) as user_id from reviews) cross join users on users.id = user_id",
+            expectPartialPushdown = true)
+        }
+        it("left outer join") {
+          testSingleReadQuery(
+            "select * from (select rating, stringIdentity(user_id) as user_id from reviews) left outer join users on users.id = user_id",
+            expectPartialPushdown = true
+          )
+        }
+        it("right outer join") {
+          testSingleReadQuery(
+            "select * from (select rating, stringIdentity(user_id) as user_id from reviews) right outer join users on users.id = user_id",
+            expectPartialPushdown = true
+          )
+        }
+        it("full outer join") {
+          testSingleReadQuery(
+            "select * from (select rating, stringIdentity(user_id) as user_id from reviews) full outer join users on users.id = user_id",
+            expectPartialPushdown = true
+          )
+        }
+      }
+
+      describe("udf in the right relation") {
+        it("explicit inner join") {
+          testSingleReadQuery(
+            "select * from users inner join (select rating, stringIdentity(user_id) as user_id from reviews) on users.id = user_id",
+            expectPartialPushdown = true)
+        }
+        it("cross join") {
+          testSingleReadQuery(
+            "select * from users cross join (select rating, stringIdentity(user_id) as user_id from reviews) on users.id = user_id",
+            expectPartialPushdown = true)
+        }
+        it("left outer join") {
+          testSingleReadQuery(
+            "select * from users left outer join (select rating, stringIdentity(user_id) as user_id from reviews) on users.id = user_id",
+            expectPartialPushdown = true
+          )
+        }
+        it("right outer join") {
+          testSingleReadQuery(
+            "select * from users right outer join (select rating, stringIdentity(user_id) as user_id from reviews) on users.id = user_id",
+            expectPartialPushdown = true
+          )
+        }
+        it("full outer join") {
+          testSingleReadQuery(
+            "select * from users full outer join (select rating, stringIdentity(user_id) as user_id from reviews) on users.id = user_id",
+            expectPartialPushdown = true
+          )
+        }
+      }
+
+      describe("udf in the condition") {
+        it("explicit inner join") {
+          testSingleReadQuery(
+            "select * from users inner join reviews on stringIdentity(users.id) = stringIdentity(reviews.user_id)",
+            expectPartialPushdown = true)
+        }
+        it("cross join") {
+          testSingleReadQuery(
+            "select * from users cross join reviews on stringIdentity(users.id) = stringIdentity(reviews.user_id)",
+            expectPartialPushdown = true)
+        }
+        it("left outer join") {
+          testSingleReadQuery(
+            "select * from users left outer join reviews on stringIdentity(users.id) = stringIdentity(reviews.user_id)",
+            expectPartialPushdown = true)
+        }
+        it("right outer join") {
+          testSingleReadQuery(
+            "select * from users right outer join reviews on stringIdentity(users.id) = stringIdentity(reviews.user_id)",
+            expectPartialPushdown = true)
+        }
+        it("full outer join") {
+          testSingleReadQuery(
+            "select * from users full outer join reviews on stringIdentity(users.id) = stringIdentity(reviews.user_id)",
+            expectPartialPushdown = true)
+        }
+      }
+
+      describe("outer joins with empty condition") {
+        it("left outer join") {
+          testQuery(
+            "select * from users left outer join (select rating from reviews order by rating limit 10)",
+            expectPartialPushdown = true)
+        }
+        it("right outer join") {
+          testSingleReadQuery(
+            "select * from users right outer join (select rating from reviews order by rating limit 10)",
+            expectPartialPushdown = true)
+        }
+        it("full outer join") {
+          testQuery(
+            "select * from users full outer join (select rating from reviews order by rating limit 10)",
+            expectPartialPushdown = true)
+        }
+      }
+
+      describe("different dml jdbc options") {
+        def testPushdown(joinType: String): Unit = {
+          val df1 =
+            spark.read
+              .format(DefaultSource.MEMSQL_SOURCE_NAME_SHORT)
+              .options(Map("dmlEndpoint" -> "host1:1020,host2:1010"))
+              .load("testdb.users")
+          val df2 =
+            spark.read
+              .format(DefaultSource.MEMSQL_SOURCE_NAME_SHORT)
+              .options(Map("dmlEndpoint" -> "host3:1020,host2:1010"))
+              .load("testdb.reviews")
+
+          val joinedDf = df1.join(df2, df1("id") === df2("user_id"), joinType)
+          log.debug(joinedDf.queryExecution.optimizedPlan.toString())
+          assert(
+            joinedDf.queryExecution.optimizedPlan match {
+              case SQLGen.Relation(_) => false
+              case _                  => true
+            },
+            "Join of the relations with different jdbc connection options should not be pushed down"
+          )
+        }
+
+        it("explicit inner join") {
+          testPushdown("inner")
+        }
+        it("cross join") {
+          testPushdown("cross")
+        }
+        it("left outer join") {
+          testPushdown("leftouter")
+        }
+        it("right outer join") {
+          testPushdown("rightouter")
+        }
+        it("full outer join") {
+          testPushdown("fullouter")
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Summary:
In the old code if the condition was None we returned None and if we failed to pushdown we returned Some(None)
As a result, when we failed to pushdown we generated query with empty condition and when condition is empty we stopped the pushdown.
This beghaviour is fixed.
Also added more tests for joins and added check that both relations has the same jdbc connection options before joining them
**Docs impact**:

Test Plan: suite tests

Reviewers: carl, iblinov-ua

Subscribers: engineering-list

JIRA Issues: PLAT-4391

Differential Revision: https://grizzly.internal.memcompute.com/D41444