### PR TITLE
Bump spark-daria and spark-fast-tests versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,10 +28,10 @@ lazy val root = project
       "org.mariadb.jdbc"       % "mariadb-java-client"     % "2.+",
       "io.spray"               %% "spray-json"             % "1.3.5",
       // test dependencies
-      "org.scalatest"  %% "scalatest"       % "3.1.0"         % Test,
-      "org.scalacheck" %% "scalacheck"      % "1.14.1"        % Test,
-      "mrpowers"       % "spark-daria"      % "0.35.0-s_2.11" % Test,
-      "MrPowers"       % "spark-fast-tests" % "0.21.0-s_2.11" % Test
+      "org.scalatest"       %% "scalatest"        % "3.1.0"  % Test,
+      "org.scalacheck"      %% "scalacheck"       % "1.14.1" % Test,
+      "com.github.mrpowers" %% "spark-fast-tests" % "0.21.3" % Test,
+      "com.github.mrpowers" %% "spark-daria"      % "0.38.2" % Test
     ),
     Test / testOptions += Tests.Argument("-oF"),
     Test / fork := true


### PR DESCRIPTION
spark-daria and spark-fast-tests have been transitioned to a standard publishing process.  They're both being cross compiled with Scala 2.11 & Scala 2.12.

This standard SBT dependency approach will make it easier for the memsql-spark-connector library to be cross compiled with Scala 2.12.