### PR TITLE
Closed connection during writes

### DIFF
--- a/src/main/scala/com/singlestore/spark/SinglestoreLoadDataWriter.scala
+++ b/src/main/scala/com/singlestore/spark/SinglestoreLoadDataWriter.scala
@@ -249,9 +249,14 @@ class LoadDataWriter(createDatabaseWriter: () => (OutputStream, Future[Long]), c
   }
 
   override def commit(): WriterCommitMessage = {
-    Try(outputstream.close())
-    Await.result(writeFuture, Duration.Inf)
-    conn.commit()
+    try {
+      Try(outputstream.close())
+      Await.result(writeFuture, Duration.Inf)
+      conn.commit()
+    } finally {
+      conn.close()
+    }
+
     new WriteSuccess
   }
 
@@ -323,10 +328,15 @@ class AvroDataWriter(avroSchema: Schema,
   }
 
   override def commit(): WriterCommitMessage = {
-    encoder.flush()
-    Try(outputstream.close())
-    Await.result(writeFuture, Duration.Inf)
-    conn.commit()
+    try {
+      encoder.flush()
+      Try(outputstream.close())
+      Await.result(writeFuture, Duration.Inf)
+      conn.commit()
+    } finally {
+      conn.close()
+    }
+
     new WriteSuccess
   }
 


### PR DESCRIPTION
This PR restores proper connection closure logic that was unintentionally removed in [8a30b37](https://github.com/memsql/singlestore-spark-connector/commit/8a30b37349cc2e856553062f53c026b135cf20e3)